### PR TITLE
Prototype Facebook Pipeline

### DIFF
--- a/code_schemes/facebook_s01e01.json
+++ b/code_schemes/facebook_s01e01.json
@@ -1,0 +1,194 @@
+{
+    "SchemeID": "Scheme-b744fd73",
+    "Name": "Facebook S01E01",
+    "Version": "0.0.0.1",
+    "Codes": [
+      {
+        "CodeID": "code-2a349eca",
+        "CodeType": "Normal",
+        "DisplayText": "yes test",
+        "NumericValue": 1,
+        "StringValue": "rumour_test",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-00defa83",
+        "CodeType": "Normal",
+        "DisplayText": "no test",
+        "NumericValue": 2,
+        "StringValue": "no_test",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NA-f93d3eb7",
+        "CodeType": "Control",
+        "ControlCode": "NA",
+        "DisplayText": "NA (missing)",
+        "NumericValue": -10,
+        "StringValue": "NA",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NS-2c11b7c9",
+        "CodeType": "Control",
+        "ControlCode": "NS",
+        "DisplayText": "NS (skip)",
+        "NumericValue": -20,
+        "StringValue": "NS",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NC-42f1d983",
+        "CodeType": "Control",
+        "ControlCode": "NC",
+        "DisplayText": "NC (not coded)",
+        "NumericValue": -30,
+        "StringValue": "NC",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NR-5e3eee23",
+        "CodeType": "Control",
+        "ControlCode": "NR",
+        "DisplayText": "NR (not reviewed)",
+        "NumericValue": -40,
+        "StringValue": "NR",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NIC-99631cb8",
+        "CodeType": "Control",
+        "ControlCode": "NIC",
+        "DisplayText": "NIC (not internally consistent)",
+        "NumericValue": -50,
+        "StringValue": "NIC",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-STOP-08b832a8",
+        "CodeType": "Control",
+        "ControlCode": "STOP",
+        "DisplayText": "STOP",
+        "NumericValue": -90,
+        "StringValue": "STOP",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-WS-adb25603b7af",
+        "CodeType": "Control",
+        "ControlCode": "WS",
+        "DisplayText": "WS (wrong scheme)",
+        "NumericValue": -100,
+        "StringValue": "WS",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-CE-016c1e22",
+        "CodeType": "Control",
+        "ControlCode": "CE",
+        "DisplayText": "CE (coding error)",
+        "NumericValue": -110,
+        "StringValue": "CE",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-PB-a434a800",
+        "CodeType": "Meta",
+        "MetaCode": "push_back",
+        "DisplayText": "meta: push back",
+        "NumericValue": -100000,
+        "StringValue": "push_back",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SQ-5e8f0122",
+        "CodeType": "Meta",
+        "MetaCode": "showtime_question",
+        "DisplayText": "meta: showtime question",
+        "NumericValue": -100030,
+        "StringValue": "showtime_question",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-G-97cb3199",
+        "CodeType": "Meta",
+        "MetaCode": "greeting",
+        "DisplayText": "meta: greeting",
+        "NumericValue": -100020,
+        "StringValue": "greeting",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-OI-c5f1d054",
+        "CodeType": "Meta",
+        "MetaCode": "opt-in",
+        "DisplayText": "meta: opt-in",
+        "NumericValue": -100040,
+        "StringValue": "opt_in",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SC-a3a065bc",
+        "CodeType": "Meta",
+        "MetaCode": "similar_content",
+        "DisplayText": "meta: similar content",
+        "NumericValue": -100050,
+        "StringValue": "similar_content",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-PI-83b90d32",
+        "CodeType": "Meta",
+        "MetaCode": "participation_incentive",
+        "DisplayText": "meta: participation incentive",
+        "NumericValue": -100060,
+        "StringValue": "participation_incentive",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-EC-3a704f5b",
+        "CodeType": "Meta",
+        "MetaCode": "exclusion_complaint",
+        "DisplayText": "meta: exclusion complaint",
+        "NumericValue": -100070,
+        "StringValue": "exclusion_complaint",
+        "VisibleInCoda": true
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": false,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": false,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": false
+      }
+    ]
+}

--- a/code_schemes/facebook_s01e01.json
+++ b/code_schemes/facebook_s01e01.json
@@ -8,7 +8,7 @@
         "CodeType": "Normal",
         "DisplayText": "yes test",
         "NumericValue": 1,
-        "StringValue": "rumour_test",
+        "StringValue": "yes_test",
         "VisibleInCoda": true
       },
       {

--- a/configuration/code_imputation_functions.py
+++ b/configuration/code_imputation_functions.py
@@ -1,0 +1,147 @@
+import time
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.cleaners.location_tools import SomaliaLocations
+from core_data_modules.data_models.code_scheme import CodeTypes
+from core_data_modules.traced_data import Metadata
+
+from configuration.code_schemes import CodeSchemes
+
+
+def make_location_code(scheme, clean_value):
+    if clean_value == Codes.NOT_CODED:
+        return scheme.get_code_with_control_code(Codes.NOT_CODED)
+    else:
+        return scheme.get_code_with_match_value(clean_value)
+
+
+def impute_somalia_location_codes(user, data, location_configurations):
+    for td in data:
+        # Up to 1 location code should have been assigned in Coda. Search for that code,
+        # ensuring that only 1 has been assigned or, if multiple have been assigned, that they are non-conflicting
+        # control codes
+        location_code = None
+
+        for cc in location_configurations:
+            coda_code = cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"])
+            if location_code is not None:
+                if not (
+                        coda_code.code_id == location_code.code_id or coda_code.control_code == Codes.NOT_REVIEWED):
+                    location_code = CodeSchemes.MOGADISHU_SUB_DISTRICT.get_code_with_control_code(Codes.CODING_ERROR)
+            elif coda_code.control_code != Codes.NOT_REVIEWED:
+                location_code = coda_code
+
+        # If no code was found, then this location is still not reviewed.
+        # Synthesise a NOT_REVIEWED code accordingly.
+        if location_code is None:
+            location_code = CodeSchemes.MOGADISHU_SUB_DISTRICT.get_code_with_control_code(Codes.NOT_REVIEWED)
+
+        # If a control code was found, set all other location keys to that control code,
+        # otherwise convert the provided location to the other locations in the hierarchy.
+        if location_code.code_type == CodeTypes.CONTROL:
+            for cc in location_configurations:
+                td.append_data({
+                    cc.coded_field: CleaningUtils.make_label_from_cleaner_code(
+                        cc.code_scheme,
+                        cc.code_scheme.get_code_with_control_code(location_code.control_code),
+                        Metadata.get_call_location()
+                    ).to_dict()
+                }, Metadata(user, Metadata.get_call_location(), time.time()))
+        elif location_code.code_type == CodeTypes.META:
+            for cc in location_configurations:
+                td.append_data({
+                    cc.coded_field: CleaningUtils.make_label_from_cleaner_code(
+                        cc.code_scheme,
+                        cc.code_scheme.get_code_with_meta_code(location_code.meta_code),
+                        Metadata.get_call_location()
+                    ).to_dict()
+                }, Metadata(user, Metadata.get_call_location(), time.time()))
+        else:
+            assert location_code.code_type == CodeTypes.NORMAL
+            location = location_code.match_values[0]
+            td.append_data({
+                "mogadishu_sub_district_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.MOGADISHU_SUB_DISTRICT,
+                    make_location_code(CodeSchemes.MOGADISHU_SUB_DISTRICT,
+                                       SomaliaLocations.mogadishu_sub_district_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict(),
+                "district_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.SOMALIA_DISTRICT,
+                    make_location_code(CodeSchemes.SOMALIA_DISTRICT,
+                                       SomaliaLocations.district_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict(),
+                "region_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.SOMALIA_REGION,
+                    make_location_code(CodeSchemes.SOMALIA_REGION,
+                                       SomaliaLocations.region_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict(),
+                "state_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.SOMALIA_STATE,
+                    make_location_code(CodeSchemes.SOMALIA_STATE,
+                                       SomaliaLocations.state_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict(),
+                "zone_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.SOMALIA_ZONE,
+                    make_location_code(CodeSchemes.SOMALIA_ZONE,
+                                       SomaliaLocations.zone_for_location_code(location)),
+                    Metadata.get_call_location()).to_dict()
+            }, Metadata(user, Metadata.get_call_location(), time.time()))
+
+        # Impute zone from operator
+        if "location_raw" not in td:
+            operator_str = CodeSchemes.SOMALIA_OPERATOR.get_code_with_code_id(td["operator_coded"]["CodeID"]).string_value
+            zone_str = SomaliaLocations.zone_for_operator_code(operator_str)
+
+            td.append_data({
+                "zone_coded": CleaningUtils.make_label_from_cleaner_code(
+                    CodeSchemes.SOMALIA_ZONE,
+                    make_location_code(CodeSchemes.SOMALIA_ZONE,
+                                       SomaliaLocations.state_for_location_code(zone_str)),
+                    Metadata.get_call_location()).to_dict()
+            }, Metadata(user, Metadata.get_call_location(), time.time()))
+
+
+def impute_age_category(user, data, age_configurations):
+    # TODO: By accepting a list of age_configurations but then requiring that list to contain code schemes in a
+    #       certain order, it looks like we're providing more flexibility than we actually do. We should change this
+    #       to explicitly accept age and age_category configurations, which requires refactoring all of the
+    #       code imputation functions.
+    age_cc = age_configurations[0]
+    age_category_cc = age_configurations[1]
+
+    age_categories = {
+        (10, 14): "10 to 14",
+        (15, 17): "15 to 17",
+        (18, 35): "18 to 35",
+        (36, 54): "36 to 54",
+        (55, 99): "55 to 99"
+    }
+
+    for td in data:
+        age_label = td[age_cc.coded_field]
+        age_code = age_cc.code_scheme.get_code_with_code_id(age_label["CodeID"])
+
+        if age_code.code_type == CodeTypes.NORMAL:
+            # TODO: If these age categories are standard across projects, move this to Core as a new cleaner.
+            age_category = None
+            for age_range, category in age_categories.items():
+                if age_range[0] <= age_code.numeric_value <= age_range[1]:
+                    age_category = category
+            assert age_category is not None
+
+            age_category_code = age_category_cc.code_scheme.get_code_with_match_value(age_category)
+        elif age_code.code_type == CodeTypes.META:
+            age_category_code = age_category_cc.code_scheme.get_code_with_meta_code(age_code.meta_code)
+        else:
+            assert age_code.code_type == CodeTypes.CONTROL
+            age_category_code = age_category_cc.code_scheme.get_code_with_control_code(age_code.control_code)
+
+        age_category_label = CleaningUtils.make_label_from_cleaner_code(
+            age_category_cc.code_scheme, age_category_code, Metadata.get_call_location()
+        )
+
+        td.append_data(
+            {age_category_cc.coded_field: age_category_label.to_dict()},
+            Metadata(user, Metadata.get_call_location(), time.time())
+        )

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -12,4 +12,4 @@ def _open_scheme(filename):
 class CodeSchemes(object):
     FACEBOOK_S01E01 = _open_scheme("facebook_s01e01.json")
 
-    WS_CORRECT_DATASET = _open_scheme("facebook_s01e01.json")
+    WS_CORRECT_DATASET = None  # TODO Add scheme

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -1,0 +1,15 @@
+import json
+
+from core_data_modules.data_models import CodeScheme
+
+
+def _open_scheme(filename):
+    with open(f"code_schemes/{filename}", "r") as f:
+        firebase_map = json.load(f)
+        return CodeScheme.from_firebase_map(firebase_map)
+
+
+class CodeSchemes(object):
+    FACEBOOK_S01E01 = _open_scheme("facebook_s01e01.json")
+
+    WS_CORRECT_DATASET = _open_scheme("facebook_s01e01.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -1,0 +1,62 @@
+from core_data_modules.cleaners import somali, swahili, Codes
+from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
+
+from configuration import code_imputation_functions
+from configuration.code_schemes import CodeSchemes
+from src.lib.configuration_objects import CodingConfiguration, CodingModes, CodingPlan
+
+
+def clean_age_with_range_filter(text):
+    """
+    Cleans age from the given `text`, setting to NC if the cleaned age is not in the range 10 <= age < 100.
+    """
+    age = swahili.DemographicCleaner.clean_age(text)
+    if type(age) == int and 10 <= age < 100:
+        return str(age)
+        # TODO: Once the cleaners are updated to not return Codes.NOT_CODED, this should be updated to still return
+        #       NC in the case where age is an int but is out of range
+    else:
+        return Codes.NOT_CODED
+
+
+def clean_district_if_no_mogadishu_sub_district(text):
+    mogadishu_sub_district = somali.DemographicCleaner.clean_mogadishu_sub_district(text)
+    if mogadishu_sub_district == Codes.NOT_CODED:
+        return somali.DemographicCleaner.clean_somalia_district(text)
+    else:
+        return Codes.NOT_CODED
+
+
+def get_rqa_coding_plans(pipeline_name):
+    if pipeline_name == "USAID-IBTCI-Facebook":
+        return [
+            CodingPlan(raw_field="facebook_s01e01_raw",
+                       time_field="sent_on",
+                       run_id_field="facebook_s01e01_run_id",
+                       coda_filename="USAID_IBTCI_facebook_s01e01.json",
+                       icr_filename="facebook_s01e01.csv",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.MULTIPLE,
+                               code_scheme=CodeSchemes.FACEBOOK_S01E01,
+                               coded_field="facebook_s01e01_coded",
+                               analysis_file_key="facebook_s01e01",
+                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S01E01, x, y)
+                           )
+                       ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate)
+        ]
+    else:
+        return []
+
+
+def get_demog_coding_plans(pipeline_name):
+    return []
+
+
+def get_follow_up_coding_plans(pipeline_name):
+    return []
+
+
+def get_ws_correct_dataset_scheme(pipeline_name):
+    return CodeSchemes.WS_CORRECT_DATASET

--- a/configuration/docker_image_project_name.txt
+++ b/configuration/docker_image_project_name.txt
@@ -1,0 +1,1 @@
+usaid-ibtci

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -1,0 +1,35 @@
+{
+  "PipelineName": "USAID-IBTCI-Facebook",
+  "RawDataSources": [
+    {
+      "SourceType": "Facebook",
+      "PageID": "imaqalcampaign",
+      "TokenFileURL": "gs://avf-credentials/imaqalcampaign-facebook-token.txt"
+    }
+  ],
+  "RapidProKeyRemappings": [
+    {"RapidProKey": "avf_facebook_id", "PipelineKey": "uid"},
+
+    {"RapidProKey": "message", "PipelineKey": "facebook_s01e01_raw"},
+    {"RapidProKey": "message_created_time", "PipelineKey": "sent_on"}
+  ],
+  "ProjectStartDate": "2000-01-01T00:00:00+03:00",
+  "ProjectEndDate": "2100-01-01T00:00:00+03:00",
+  "FilterTestMessages": false,
+  "MoveWSMessages": false,
+  "AutomatedAnalysis": {
+    "GenerateRegionThemeDistributionMaps": false,
+    "GenerateDistrictThemeDistributionMaps": false,
+    "GenerateMogadishuThemeDistributionMaps": false
+  },
+  "DriveUpload": {
+    "DriveCredentialsFileURL": "gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
+    "ProductionUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_production.csv",
+    "MessagesUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_messages.csv",
+    "IndividualsUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_individuals.csv",
+    "AutomatedAnalysisDir": "usaid_ibtci_analysis_outputs/facebook/automated_analysis"
+  },
+  "MemoryProfileUploadBucket":"gs://avf-pipeline-logs-performance-nearline",
+  "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
+  "BucketDirPath": "2020/USAID-IBTCI-Facebook/"
+}

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -31,5 +31,5 @@
   },
   "MemoryProfileUploadBucket":"gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2020/USAID-IBTCI-Facebook/"
+  "BucketDirPath": "2020/USAID-IBTCI/Facebook/"
 }

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -206,8 +206,12 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
 
     traced_comments = facebook.convert_facebook_comments_to_traced_data(user, raw_comments)
 
-    raw_comments_output_path = f"{raw_data_dir}/facebook_raw.json"
-    traced_comments_output_path = f"{raw_data_dir}/fb-test.jsonl"
+    # Note: using [0] for now for compliance with get_activation_flow_names returning a list.
+    # TODO: Rename get_activation_flows to something that makes more sense for Facebook
+    # TODO: Support processing a list of items from Facebook, e.g. requests for data by week, rather than just
+    #       taking the first item from the list.
+    traced_comments_output_path = f"{raw_data_dir}/{facebook_source.get_activation_flow_names()[0]}.jsonl"
+    raw_comments_output_path = f"{raw_data_dir}/{facebook_source.get_activation_flow_names()[0]}_raw.json"
 
     log.info(f"Saving {len(raw_comments)} raw comments to {raw_comments_output_path}...")
     IOUtils.ensure_dirs_exist_for_file(raw_comments_output_path)

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -17,8 +17,9 @@ from rapid_pro_tools.rapid_pro_client import RapidProClient
 from storage.google_cloud import google_cloud_utils
 from temba_client.v2 import Contact, Run
 
+from src.facebook_client import FacebookClient
 from src.lib import PipelineConfiguration
-from src.lib.pipeline_configuration import RapidProSource, GCloudBucketSource, RecoveryCSVSource
+from src.lib.pipeline_configuration import RapidProSource, GCloudBucketSource, RecoveryCSVSource, FacebookSource
 from configuration.code_imputation_functions import CodeSchemes
 
 log = Logger(__name__)
@@ -193,6 +194,28 @@ def fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_d
         log.info(f"Exported TracedData")
 
 
+def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, facebook_source):
+    log.info("Fetching data from Facebook...")
+    log.info("Downloading Facebook access token...")
+    facebook_token = google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path, facebook_source.token_file_url).strip()
+
+    facebook = FacebookClient(facebook_token)
+
+    raw_comments = facebook.get_all_comments_on_page(facebook_source.page_id)
+    print(raw_comments)
+
+    # Convert the comments to TracedData
+    traced_comments = facebook.convert_facebook_comments_to_traced_data(user, raw_comments)
+
+    traced_comments_output_path = f"{raw_data_dir}/fb-test.jsonl"
+    log.info(f"Saving {len(traced_comments)} traced comments to {traced_comments_output_path}...")
+    IOUtils.ensure_dirs_exist_for_file(traced_comments_output_path)
+    with open(traced_comments_output_path, "w") as traced_comments_output_file:
+        TracedDataJsonIO.export_traced_data_iterable_to_jsonl(traced_comments, traced_comments_output_file)
+    log.info(f"Saved {len(traced_comments)} traced comments")
+
+
 def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_path, raw_data_dir):
     # Read the settings from the configuration file
     log.info("Loading Pipeline Configuration File...")
@@ -201,18 +224,19 @@ def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_p
     Logger.set_project_name(pipeline_configuration.pipeline_name)
     log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
 
-    log.info("Downloading Firestore UUID Table credentials...")
-    firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
-        google_cloud_credentials_file_path,
-        pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
-    ))
+    if pipeline_configuration.phone_number_uuid_table is not None:
+        log.info("Downloading Firestore UUID Table credentials...")
+        firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
+            google_cloud_credentials_file_path,
+            pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
+        ))
 
-    phone_number_uuid_table = FirestoreUuidTable(
-        pipeline_configuration.phone_number_uuid_table.table_name,
-        firestore_uuid_table_credentials,
-        "avf-phone-uuid-"
-    )
-    log.info("Initialised the Firestore UUID table")
+        phone_number_uuid_table = FirestoreUuidTable(
+            pipeline_configuration.phone_number_uuid_table.table_name,
+            firestore_uuid_table_credentials,
+            "avf-phone-uuid-"
+        )
+        log.info("Initialised the Firestore UUID table")
 
     log.info(f"Fetching data from {len(pipeline_configuration.raw_data_sources)} sources...")
     for i, raw_data_source in enumerate(pipeline_configuration.raw_data_sources):
@@ -225,7 +249,8 @@ def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_p
         elif isinstance(raw_data_source, RecoveryCSVSource):
             fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table,
                                     raw_data_source)
-
+        elif isinstance(raw_data_source, FacebookSource):
+            fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, raw_data_source)
         else:
             assert False, f"Unknown raw_data_source type {type(raw_data_source)}"
 

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -203,12 +203,18 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
     facebook = FacebookClient(facebook_token)
 
     raw_comments = facebook.get_all_comments_on_page(facebook_source.page_id)
-    print(raw_comments)
 
-    # Convert the comments to TracedData
     traced_comments = facebook.convert_facebook_comments_to_traced_data(user, raw_comments)
 
+    raw_comments_output_path = f"{raw_data_dir}/facebook_raw.json"
     traced_comments_output_path = f"{raw_data_dir}/fb-test.jsonl"
+
+    log.info(f"Saving {len(raw_comments)} raw comments to {raw_comments_output_path}...")
+    IOUtils.ensure_dirs_exist_for_file(raw_comments_output_path)
+    with open(raw_comments_output_path, "w") as raw_comments_output_path:
+        json.dump(raw_comments, raw_comments_output_path)
+    log.info(f"Saved {len(raw_comments)} raw comments")
+
     log.info(f"Saving {len(traced_comments)} traced comments to {traced_comments_output_path}...")
     IOUtils.ensure_dirs_exist_for_file(traced_comments_output_path)
     with open(traced_comments_output_path, "w") as traced_comments_output_file:

--- a/src/apply_manual_codes.py
+++ b/src/apply_manual_codes.py
@@ -95,18 +95,19 @@ class ApplyManualCodes(object):
                     if f is not None:
                         f.close()
 
-            f = None
-            try:
-                if path.exists(coda_input_path):
-                    f = open(coda_input_path, "r")
+            if PipelineConfiguration.WS_CORRECT_DATASET_SCHEME is not None:
+                f = None
+                try:
+                    if path.exists(coda_input_path):
+                        f = open(coda_input_path, "r")
 
-                TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
-                    user, data, plan.id_field,
-                    {f"{plan.raw_field}_correct_dataset": PipelineConfiguration.WS_CORRECT_DATASET_SCHEME}, f
-                )
-            finally:
-                if f is not None:
-                    f.close()
+                    TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
+                        user, data, plan.id_field,
+                        {f"{plan.raw_field}_correct_dataset": PipelineConfiguration.WS_CORRECT_DATASET_SCHEME}, f
+                    )
+                finally:
+                    if f is not None:
+                        f.close()
 
         # Label data for which there is no response as TRUE_MISSING.
         # Label data for which the response is the empty string as NOT_CODED.

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -10,7 +10,7 @@ from dateutil.parser import isoparse
 log = Logger(__name__)
 
 _BASE_URL = "https://graph.facebook.com/v8.0"
-_MAX_LIMIT = 100
+_MAX_RESULTS_PER_PAGE = 100  # For paged requests, the maximum number of records to request in each page
 
 # TODO: Move to a new repo at AfricasVoices/SocialMediaTools
 # Included in project source for now because it's likely to evolve very rapidly during the initial experiments.
@@ -51,7 +51,7 @@ class FacebookClient(object):
             f"/{page_id}/published_posts",
             {
                 "fields": ",".join(fields),
-                "limit": _MAX_LIMIT
+                "limit": _MAX_RESULTS_PER_PAGE
             }
         )
         log.info(f"Fetched {len(posts)} posts")
@@ -62,7 +62,7 @@ class FacebookClient(object):
             f"/{post_id}/comments",
             {
                 "fields": ",".join(fields),
-                "limit": _MAX_LIMIT,
+                "limit": _MAX_RESULTS_PER_PAGE,
                 "filter": "toplevel"
             }
         )
@@ -73,7 +73,7 @@ class FacebookClient(object):
             f"/{post_id}/comments",
             {
                 "fields": ",".join(fields),
-                "limit": _MAX_LIMIT,
+                "limit": _MAX_RESULTS_PER_PAGE,
                 "filter": "stream"
             }
         )

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -1,0 +1,81 @@
+import json
+
+from core_data_modules.data_models import validators
+from core_data_modules.logging import Logger
+import requests
+from core_data_modules.traced_data import TracedData, Metadata
+from core_data_modules.util import TimeUtils
+from dateutil.parser import isoparse
+
+log = Logger(__name__)
+
+_BASE_URL = "https://graph.facebook.com/v8.0"
+_MAX_LIMIT = 100
+
+# TODO: Move to a new repo at AfricasVoices/SocialMediaTools
+# Included in project source for now because it's likely to evolve very rapidly during the initial experiments.
+class FacebookClient(object):
+    def __init__(self, access_token):
+        self._access_token = access_token
+
+    def _make_get_request(self, endpoint, params):
+        params = params.copy()
+        params["access_token"] = self._access_token
+
+        next_url = f"{_BASE_URL}{endpoint}"
+        result = []
+        while next_url is not None:
+            print(f"getting {next_url}")
+            response = requests.get(next_url, params).json()
+            result.extend(response["data"])
+            if "paging" in response:
+                next_url = response["paging"].get("next")
+            else:
+                next_url = None
+        return result
+
+    def get_all_posts_from_page(self, page_id, fields=["attachments", "created_time", "message"]):
+        return self._make_get_request(
+            f"/{page_id}/published_posts",
+            {
+                "fields": ",".join(fields),
+                "limit": _MAX_LIMIT
+            }
+        )
+
+    def get_comments_on_post(self, post_id, fields=["attachments", "created_time", "message"]):
+        return self._make_get_request(
+            f"/{post_id}/comments",
+            {
+                "fields": ",".join(fields),
+                "limit": _MAX_LIMIT
+            }
+        )
+
+    def get_all_comments_on_page(self, page_id, fields=["attachments", "created_time", "message"]):
+        posts = self.get_all_posts_from_page(page_id)
+        comments = []
+        for post in [posts[3]]:
+            comments.extend(self.get_comments_on_post(post["id"], fields))
+        return comments
+
+    @staticmethod
+    def convert_facebook_comments_to_traced_data(user, raw_comments):
+        log.info(f"Converting {len(raw_comments)} Facebook comments to TracedData...")
+
+        traced_comments = []
+        for comment in raw_comments:
+            comment["created_time"] = isoparse(comment["created_time"]).isoformat()
+            validators.validate_utc_iso_string(comment["created_time"])
+
+            traced_comments.append(TracedData(
+                {
+                    "avf_facebook_id": None,  # TODO: De-identify a user's FB id here if possible instead
+                    "facebook_message_id": comment["id"],
+                    "message": comment["message"],
+                    "message_created_time": comment["created_time"],
+                },
+                Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())
+            ))
+
+        return traced_comments

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -79,21 +79,25 @@ class FacebookClient(object):
         log.info(f"Converting {len(raw_comments)} Facebook comments to TracedData...")
 
         traced_comments = []
-        id = 0
+        # Use a placeholder avf facebook id for now, to make the individuals file work until we know if we'll be able
+        # to see Facebook user ids or not.
+        # TODO: If we get ids from FB, de-identify instead of incrementing this placeholder;
+        #       If we don't get ids from FB, re-configure the pipeline to make processing individuals optional
+        avf_facebook_id = 0
         for comment in raw_comments:
             comment["created_time"] = isoparse(comment["created_time"]).isoformat()
             validators.validate_utc_iso_string(comment["created_time"])
 
             traced_comments.append(TracedData(
                 {
-                    "avf_facebook_id": id,  # TODO: De-identify a user's FB id here if possible instead
+                    "avf_facebook_id": avf_facebook_id,  # TODO: De-identify a user's FB id here if possible instead
                     "facebook_message_id": comment["id"],
                     "message": comment["message"],
                     "message_created_time": comment["created_time"],
                 },
                 Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())
             ))
-            id += 1
+            avf_facebook_id += 1
 
         log.info(f"Converted {len(traced_comments)} Facebook comments to TracedData")
 

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -87,7 +87,8 @@ class FacebookClient(object):
         # Posts that were used as adverts are returned twice by Facebook, one post representing the page post and
         # one representing the advert. Both 'posts' have a comments edge pointing to the same dataset, so reading
         # both would lead to duplicated comments in the returned data.
-        # We solve this by pre-filtering for posts that were not created inline i.e. the original page post only.
+        # We solve this by pre-filtering for posts that were not created inline i.e. we for the original page
+        # posts only.
         log.info("Filtering out posts that were created inline")
         posts = [p for p in posts if p.get("is_inline_created") == False]
         log.info(f"Filtered out posts that were created inline. {len(posts)} remain")

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -45,7 +45,7 @@ class FacebookClient(object):
             next_url = response.json()["paging"].get("next")
         return result
 
-    def get_all_posts_from_page(self, page_id, fields=["attachments", "created_time", "message"]):
+    def get_all_posts_published_by_page(self, page_id, fields=["attachments", "created_time", "message"]):
         log.debug(f"Fetching all posts published by page '{page_id}'...")
         posts = self._make_paged_get_request(
             f"/{page_id}/published_posts",
@@ -82,7 +82,7 @@ class FacebookClient(object):
 
     def get_all_comments_on_page(self, page_id, fields=["parent", "attachments", "created_time", "message"]):
         log.info(f"Fetching all comments on page '{page_id}'...")
-        posts = self.get_all_posts_from_page(page_id, fields=["id", "is_inline_created"])
+        posts = self.get_all_posts_published_by_page(page_id, fields=["id", "is_inline_created"])
 
         # Posts that were used as adverts are returned twice by Facebook, one post representing the page post and
         # one representing the advert. Both 'posts' have a comments edge pointing to the same dataset, so reading

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -18,24 +18,28 @@ class FacebookClient(object):
     def __init__(self, access_token):
         self._access_token = access_token
 
-    def _make_get_request(self, endpoint, params):
+    def _make_get_request(self, endpoint, params=None):
+        if params is None:
+            params = {}
         params = params.copy()
         params["access_token"] = self._access_token
 
-        next_url = f"{_BASE_URL}{endpoint}"
-        result = []
+        url = f"{_BASE_URL}{endpoint}"
+        return requests.get(url, params)
+
+    def _make_paged_get_request(self, endpoint, params=None):
+        response = self._make_get_request(endpoint, params)
+        result = response.json()["data"]
+
+        next_url = response.json().get("paging", {}).get("next")
         while next_url is not None:
-            print(f"getting {next_url}")
-            response = requests.get(next_url, params).json()
-            result.extend(response["data"])
-            if "paging" in response:
-                next_url = response["paging"].get("next")
-            else:
-                next_url = None
+            response = requests.get(next_url)
+            result.extend(response.json()["data"])
+            next_url = response.json()["paging"].get("next")
         return result
 
     def get_all_posts_from_page(self, page_id, fields=["attachments", "created_time", "message"]):
-        return self._make_get_request(
+        return self._make_paged_get_request(
             f"/{page_id}/published_posts",
             {
                 "fields": ",".join(fields),
@@ -43,20 +47,32 @@ class FacebookClient(object):
             }
         )
 
-    def get_comments_on_post(self, post_id, fields=["attachments", "created_time", "message"]):
-        return self._make_get_request(
+    def get_top_level_comments_on_post(self, post_id, fields=["attachments", "created_time", "message"]):
+        return self._make_paged_get_request(
             f"/{post_id}/comments",
             {
                 "fields": ",".join(fields),
-                "limit": _MAX_LIMIT
+                "limit": _MAX_LIMIT,
+                "filter": "toplevel"
             }
         )
 
-    def get_all_comments_on_page(self, page_id, fields=["attachments", "created_time", "message"]):
+    def get_all_comments_on_post(self, post_id, fields=["parent", "attachments", "created_time", "message"]):
+        return self._make_paged_get_request(
+            f"/{post_id}/comments",
+            {
+                "fields": ",".join(fields),
+                "limit": _MAX_LIMIT,
+                "filter": "stream"
+            }
+        )
+
+    def get_all_comments_on_page(self, page_id, fields=["parent", "attachments", "created_time", "message"]):
         posts = self.get_all_posts_from_page(page_id)
         comments = []
-        for post in [posts[3]]:
-            comments.extend(self.get_comments_on_post(post["id"], fields))
+        for post in posts:  # [posts[10]]:
+            print(post)
+            comments.extend(self.get_all_comments_on_post(post["id"], fields))
         return comments
 
     @staticmethod
@@ -64,18 +80,22 @@ class FacebookClient(object):
         log.info(f"Converting {len(raw_comments)} Facebook comments to TracedData...")
 
         traced_comments = []
+        id = 0
         for comment in raw_comments:
             comment["created_time"] = isoparse(comment["created_time"]).isoformat()
             validators.validate_utc_iso_string(comment["created_time"])
 
             traced_comments.append(TracedData(
                 {
-                    "avf_facebook_id": None,  # TODO: De-identify a user's FB id here if possible instead
+                    "avf_facebook_id": id,  # TODO: De-identify a user's FB id here if possible instead
                     "facebook_message_id": comment["id"],
                     "message": comment["message"],
                     "message_created_time": comment["created_time"],
                 },
                 Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())
             ))
+            id += 1
+
+        log.info(f"Converted {len(traced_comments)} Facebook comments to TracedData")
 
         return traced_comments

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -70,8 +70,7 @@ class FacebookClient(object):
     def get_all_comments_on_page(self, page_id, fields=["parent", "attachments", "created_time", "message"]):
         posts = self.get_all_posts_from_page(page_id)
         comments = []
-        for post in posts:  # [posts[10]]:
-            print(post)
+        for post in posts:
             comments.extend(self.get_all_comments_on_post(post["id"], fields))
         return comments
 

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -39,13 +39,16 @@ class FacebookClient(object):
         return result
 
     def get_all_posts_from_page(self, page_id, fields=["attachments", "created_time", "message"]):
-        return self._make_paged_get_request(
+        log.debug(f"Fetching all posts from page '{page_id}'...")
+        posts = self._make_paged_get_request(
             f"/{page_id}/published_posts",
             {
                 "fields": ",".join(fields),
                 "limit": _MAX_LIMIT
             }
         )
+        log.info(f"Fetched {len(posts)} posts")
+        return posts
 
     def get_top_level_comments_on_post(self, post_id, fields=["attachments", "created_time", "message"]):
         return self._make_paged_get_request(
@@ -58,7 +61,8 @@ class FacebookClient(object):
         )
 
     def get_all_comments_on_post(self, post_id, fields=["parent", "attachments", "created_time", "message"]):
-        return self._make_paged_get_request(
+        log.info(f"Fetching all comments on post '{post_id}'...")
+        comments = self._make_paged_get_request(
             f"/{post_id}/comments",
             {
                 "fields": ",".join(fields),
@@ -66,12 +70,16 @@ class FacebookClient(object):
                 "filter": "stream"
             }
         )
+        log.info(f"Fetched {len(comments)} comments")
+        return comments
 
     def get_all_comments_on_page(self, page_id, fields=["parent", "attachments", "created_time", "message"]):
+        log.info(f"Fetching all comments on page '{page_id}'...")
         posts = self.get_all_posts_from_page(page_id)
         comments = []
         for post in posts:
             comments.extend(self.get_all_comments_on_post(post["id"], fields))
+        log.info(f"Fetched {len(comments)} on page '{page_id}' (from {len(posts)} posts)")
         return comments
 
     @staticmethod

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -309,13 +309,14 @@ class FacebookSource(RawDataSource):
         validators.validate_string(self.page_id, "page_id")
         validators.validate_url(self.token_file_url, "token_file_url", scheme="gs")
 
-    def get_survey_flow_names(self):
-        return []
-
+    # TODO: Rename to refer to datasets instead of flows, since 'flows' don't really make sense for Facebook
     def get_activation_flow_names(self):
         return [
-            "fb-test"
+            "facebook"
         ]
+
+    def get_survey_flow_names(self):
+        return []
 
 
 class PhoneNumberUuidTable(object):


### PR DESCRIPTION
This PR contains the minimum set of changes needed to demonstrate basic thematic analysis of Facebook messages via Coda. It uses the imaqal page for now, while we wait for the new IBTCI pages to be ready.

The plan here is to be able to provide two json configuration files, one for TextIt and one for Facebook, then run the pipeline under both configurations to produce two separate datasets. Because the pipelines were designed to handle multiple sources, the changes here are mostly standard configuration + a new fetcher for Facebook, included in the project rather than in social media tools until it stabilises.

There’s lots left to do, but this sets the overall strategy. Outstandings include:
- Rename references to Rapid Pro, flows, activation etc. to be more generic.
- Provide a mechanism for grouping facebook messages into datasets, e.g. by timestamp of the parent post, so we can distinguish responses each week.
- Handle user ids/de-identification if we can get that data from M2A, otherwise disable the individuals file as it makes no sense.
- Disable consent processing, as we need to handle consent differently for Facebook (which will most likely be to assume opt-in as long as the comment exists)
- Tag messages according to whether they are a response to a post or a response to a comment.
- Provide a means to extract both message themes and demogs from messages, if M2A decide to ask people to include e.g. an answer to the question and their location in the responses.
- Move FacebookClient to a new social media tools repo.
- Finalise control/meta codes for Facebook.