### PR TITLE
Add configuration for individual facebook datasets

### DIFF
--- a/code_schemes/facebook_s01e02.json
+++ b/code_schemes/facebook_s01e02.json
@@ -1,0 +1,194 @@
+{
+    "SchemeID": "Scheme-b5b5212f",
+    "Name": "Facebook S01E02",
+    "Version": "0.0.0.1",
+    "Codes": [
+      {
+        "CodeID": "code-2a349eca",
+        "CodeType": "Normal",
+        "DisplayText": "yes test",
+        "NumericValue": 1,
+        "StringValue": "yes_test",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-00defa83",
+        "CodeType": "Normal",
+        "DisplayText": "no test",
+        "NumericValue": 2,
+        "StringValue": "no_test",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NA-f93d3eb7",
+        "CodeType": "Control",
+        "ControlCode": "NA",
+        "DisplayText": "NA (missing)",
+        "NumericValue": -10,
+        "StringValue": "NA",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NS-2c11b7c9",
+        "CodeType": "Control",
+        "ControlCode": "NS",
+        "DisplayText": "NS (skip)",
+        "NumericValue": -20,
+        "StringValue": "NS",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NC-42f1d983",
+        "CodeType": "Control",
+        "ControlCode": "NC",
+        "DisplayText": "NC (not coded)",
+        "NumericValue": -30,
+        "StringValue": "NC",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NR-5e3eee23",
+        "CodeType": "Control",
+        "ControlCode": "NR",
+        "DisplayText": "NR (not reviewed)",
+        "NumericValue": -40,
+        "StringValue": "NR",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NIC-99631cb8",
+        "CodeType": "Control",
+        "ControlCode": "NIC",
+        "DisplayText": "NIC (not internally consistent)",
+        "NumericValue": -50,
+        "StringValue": "NIC",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-STOP-08b832a8",
+        "CodeType": "Control",
+        "ControlCode": "STOP",
+        "DisplayText": "STOP",
+        "NumericValue": -90,
+        "StringValue": "STOP",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-WS-adb25603b7af",
+        "CodeType": "Control",
+        "ControlCode": "WS",
+        "DisplayText": "WS (wrong scheme)",
+        "NumericValue": -100,
+        "StringValue": "WS",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-CE-016c1e22",
+        "CodeType": "Control",
+        "ControlCode": "CE",
+        "DisplayText": "CE (coding error)",
+        "NumericValue": -110,
+        "StringValue": "CE",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-PB-a434a800",
+        "CodeType": "Meta",
+        "MetaCode": "push_back",
+        "DisplayText": "meta: push back",
+        "NumericValue": -100000,
+        "StringValue": "push_back",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SQ-5e8f0122",
+        "CodeType": "Meta",
+        "MetaCode": "showtime_question",
+        "DisplayText": "meta: showtime question",
+        "NumericValue": -100030,
+        "StringValue": "showtime_question",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-G-97cb3199",
+        "CodeType": "Meta",
+        "MetaCode": "greeting",
+        "DisplayText": "meta: greeting",
+        "NumericValue": -100020,
+        "StringValue": "greeting",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-OI-c5f1d054",
+        "CodeType": "Meta",
+        "MetaCode": "opt-in",
+        "DisplayText": "meta: opt-in",
+        "NumericValue": -100040,
+        "StringValue": "opt_in",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SC-a3a065bc",
+        "CodeType": "Meta",
+        "MetaCode": "similar_content",
+        "DisplayText": "meta: similar content",
+        "NumericValue": -100050,
+        "StringValue": "similar_content",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-PI-83b90d32",
+        "CodeType": "Meta",
+        "MetaCode": "participation_incentive",
+        "DisplayText": "meta: participation incentive",
+        "NumericValue": -100060,
+        "StringValue": "participation_incentive",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-EC-3a704f5b",
+        "CodeType": "Meta",
+        "MetaCode": "exclusion_complaint",
+        "DisplayText": "meta: exclusion complaint",
+        "NumericValue": -100070,
+        "StringValue": "exclusion_complaint",
+        "VisibleInCoda": true
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": false,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": false,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": false
+      }
+    ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -11,5 +11,6 @@ def _open_scheme(filename):
 
 class CodeSchemes(object):
     FACEBOOK_S01E01 = _open_scheme("facebook_s01e01.json")
+    FACEBOOK_S01E02 = _open_scheme("facebook_s01e02.json")
 
     WS_CORRECT_DATASET = None  # TODO Add scheme

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -44,6 +44,21 @@ def get_rqa_coding_plans(pipeline_name):
                                fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S01E01, x, y)
                            )
                        ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate),
+            CodingPlan(raw_field="facebook_s01e02_raw",
+                       time_field="sent_on",
+                       run_id_field="facebook_s01e02_run_id",
+                       coda_filename="USAID_IBTCI_facebook_s01e02.json",
+                       icr_filename="facebook_s01e02.csv",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.MULTIPLE,
+                               code_scheme=CodeSchemes.FACEBOOK_S01E02,
+                               coded_field="facebook_s01e02_coded",
+                               analysis_file_key="facebook_s01e02",
+                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S01E02, x, y)
+                           )
+                       ],
                        raw_field_fold_strategy=FoldStrategies.concatenate)
         ]
     else:

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -4,14 +4,21 @@
     {
       "SourceType": "Facebook",
       "PageID": "imaqalcampaign",
-      "TokenFileURL": "gs://avf-credentials/imaqalcampaign-facebook-token.txt"
+      "TokenFileURL": "gs://avf-credentials/imaqalcampaign-facebook-token.txt",
+      "Datasets": [
+        {"Name": "facebook_s01e01", "PostIDs": ["427662381371142_792818351522208", "427662381371142_783679525769424"]},
+        {"Name": "facebook_s01e02", "PostIDs": ["427662381371142_770099307127446"]}
+      ]
     }
   ],
   "RapidProKeyRemappings": [
     {"RapidProKey": "avf_facebook_id", "PipelineKey": "uid"},
 
-    {"RapidProKey": "message", "PipelineKey": "facebook_s01e01_raw"},
-    {"RapidProKey": "message_created_time", "PipelineKey": "sent_on"}
+    {"RapidProKey": "facebook_s01e01.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"RapidProKey": "facebook_s01e01.message_created_time", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "facebook_s01e02.message", "PipelineKey": "facebook_s01e02_raw"},
+    {"RapidProKey": "facebook_s01e02.message_created_time", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",


### PR DESCRIPTION
This project will be running on Facebook pages that post other content, so the config expects a list of post ids for the relevant posts to download comments from. Posts are grouped into datasets so that we can collect all the posts on one topic/question into a single dataset in coda + analysis. Note that using post ids is a slow, laborious solution - we've asked M2A to include our project hashtag in all of our projects so we can have a means of automatically identifying our posts, but this PR post ids first as it is simpler and less dependent on M2A to remember our hashtag.

The design continues to mirror that of RapidProClient and RapidProSource, the main difference being the formatting of the keys, which uses '.' notation rather than the weird combination of casing, brackets, and hyphens that the rapid pro client uses.

Note that the configuration is still all placeholder, pointing to random imaqal posts for now.