### PR TITLE
Copy all fields from the facebook json to TracedData, not just a hard-coded list

### DIFF
--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -7,7 +7,7 @@
       "TokenFileURL": "gs://avf-credentials/imaqalcampaign-facebook-token.txt",
       "Datasets": [
         {"Name": "facebook_s01e01", "PostIDs": ["427662381371142_792818351522208", "427662381371142_783679525769424"]},
-        {"Name": "facebook_s01e02", "PostIDs": ["427662381371142_770099307127446"]}
+        {"Name": "facebook_s01e02", "PostIDs": ["427662381371142_765053444298699"]}
       ]
     }
   ],
@@ -15,10 +15,10 @@
     {"RapidProKey": "avf_facebook_id", "PipelineKey": "uid"},
 
     {"RapidProKey": "facebook_s01e01.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"RapidProKey": "facebook_s01e01.message_created_time", "PipelineKey": "sent_on"},
+    {"RapidProKey": "facebook_s01e01.created_time", "PipelineKey": "sent_on"},
 
     {"RapidProKey": "facebook_s01e02.message", "PipelineKey": "facebook_s01e02_raw"},
-    {"RapidProKey": "facebook_s01e02.message_created_time", "PipelineKey": "sent_on"}
+    {"RapidProKey": "facebook_s01e02.created_time", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -212,7 +212,9 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
         for post_id in dataset.post_ids:
             comments_log_path = f"{raw_data_dir}/{post_id}_comments_log.jsonl"
             with open(comments_log_path, "a") as raw_comments_log_file:
-                raw_comments.extend(facebook.get_all_comments_on_post(post_id, raw_export_log_file=raw_comments_log_file))
+                raw_comments.extend(
+                    facebook.get_all_comments_on_post(post_id, raw_export_log_file=raw_comments_log_file)
+                )
 
         # Convert the comments to TracedData.
         traced_comments = facebook.convert_facebook_comments_to_traced_data(user, dataset.name, raw_comments)

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -123,15 +123,14 @@ class FacebookClient(object):
             comment["created_time"] = isoparse(comment["created_time"]).isoformat()
             validators.validate_utc_iso_string(comment["created_time"])
 
-            traced_comments.append(TracedData(
-                {
-                    f"avf_facebook_id": f"{dataset_name}_{avf_facebook_id}",  # TODO: De-identify a user's FB id here if possible instead
-                    f"{dataset_name}.facebook_message_id": comment["id"],
-                    f"{dataset_name}.message": comment["message"],
-                    f"{dataset_name}.message_created_time": comment["created_time"],
-                },
-                Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())
-            ))
+            comment_dict = {
+                "avf_facebook_id": f"{dataset_name}_{avf_facebook_id}",  # TODO: De-identify a user's FB id here if possible instead
+            }
+            for k, v in comment.items():
+                comment_dict[f"{dataset_name}.{k}"] = v
+
+            traced_comments.append(
+                TracedData(comment_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())))
             avf_facebook_id += 1
 
         log.info(f"Converted {len(traced_comments)} Facebook comments to TracedData")


### PR DESCRIPTION
This lets us control the fields that we want to include in the TracedData from fetch_raw_data.py only, rather than needing to duplicate between there and facebook_client.py. 