### PR TITLE
Rename RapidProKeyRemappings -> SourceKeyRemappings

### DIFF
--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -27,20 +27,20 @@
       ]
     }
   ],
-  "RapidProKeyRemappings": [
-    {"RapidProKey": "avf_facebook_id", "PipelineKey": "uid"},
+  "SourceKeyRemappings": [
+    {"SourceKey": "avf_facebook_id", "PipelineKey": "uid"},
 
-    {"RapidProKey": "facebook_s01e01_dhaayow655.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"RapidProKey": "facebook_s01e01_dhaayow655.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s01e01_dhaayow655.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"SourceKey": "facebook_s01e01_dhaayow655.created_time", "PipelineKey": "sent_on"},
 
-    {"RapidProKey": "facebook_s01e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"RapidProKey": "facebook_s01e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
 
-    {"RapidProKey": "facebook_s01e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"RapidProKey": "facebook_s01e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
 
-    {"RapidProKey": "facebook_s01e02_dhaayow655.message", "PipelineKey": "facebook_s01e02_raw"},
-    {"RapidProKey": "facebook_s01e02_dhaayow655.created_time", "PipelineKey": "sent_on"}
+    {"SourceKey": "facebook_s01e02_dhaayow655.message", "PipelineKey": "facebook_s01e02_raw"},
+    {"SourceKey": "facebook_s01e02_dhaayow655.created_time", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -4,7 +4,7 @@ from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import IOUtils
 
-from src import LoadData, TranslateRapidProKeys, AutoCode, ProductionFile, \
+from src import LoadData, TranslateSourceKeys, AutoCode, ProductionFile, \
     ApplyManualCodes, AnalysisFile, WSCorrection
 from src.lib import PipelineConfiguration, MessageFilters
 
@@ -73,8 +73,8 @@ if __name__ == "__main__":
     log.info("Loading the raw data...")
     data = LoadData.load_raw_data(user, raw_data_dir, pipeline_configuration)
 
-    log.info("Translating Rapid Pro Keys...")
-    data = TranslateRapidProKeys.translate_rapid_pro_keys(user, data, pipeline_configuration)
+    log.info("Translating source Keys...")
+    data = TranslateSourceKeys.translate_source_keys(user, data, pipeline_configuration)
 
     if pipeline_configuration.move_ws_messages:
         log.info("Pre-filtering empty message objects...")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,5 +4,5 @@ from .apply_manual_codes import ApplyManualCodes
 from .auto_code import AutoCode
 from .load_data import LoadData
 from .production_file import ProductionFile
-from .translate_rapid_pro_keys import TranslateRapidProKeys
+from .translate_source_keys import TranslateSourceKeys
 from .ws_correction import WSCorrection


### PR DESCRIPTION
Now that we're supporting data fetches from sources other than Rapid Pro, 'RapidProKeyRemappings' no longer makes sense, so this PR renames this step to the more generic 'SourceKeyRemappings'