### PR TITLE
Export timestamps in messages and production file

### DIFF
--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -3,6 +3,7 @@ import argparse
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import IOUtils
+from dateutil.parser import isoparse
 
 from src import LoadData, TranslateSourceKeys, AutoCode, ProductionFile, \
     ApplyManualCodes, AnalysisFile, WSCorrection
@@ -93,6 +94,9 @@ if __name__ == "__main__":
 
     log.info("Auto Coding...")
     data = AutoCode.auto_code(user, data, pipeline_configuration, icr_output_dir, coded_dir_path)
+
+    log.info("Sorting messages by date received...")
+    data.sort(key=lambda td: isoparse(td["sent_on"]))
 
     log.info("Exporting production CSV...")
     data = ProductionFile.generate(data, production_csv_output_path)

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -118,7 +118,11 @@ class AnalysisFile(object):
         ConsentUtils.set_stopped(user, data, consent_withdrawn_key)
         ConsentUtils.set_stopped(user, folded_data, consent_withdrawn_key)
 
-        cls.export_to_csv(MESSAGES_FILE, data, csv_by_message_output_path, export_keys, consent_withdrawn_key)
+        # Add 'sent_on' as the second column in the messages file
+        messages_export_keys = export_keys.copy()
+        messages_export_keys.insert(1, "sent_on")
+
+        cls.export_to_csv(MESSAGES_FILE, data, csv_by_message_output_path, messages_export_keys, consent_withdrawn_key)
         cls.export_to_csv(INDIVIDUALS_FILE, folded_data, csv_by_individual_output_path, export_keys, consent_withdrawn_key)
 
         return data, folded_data

--- a/src/production_file.py
+++ b/src/production_file.py
@@ -6,7 +6,7 @@ from src.lib import PipelineConfiguration, MessageFilters
 class ProductionFile(object):
     @staticmethod
     def generate(data, production_csv_output_path):
-        production_keys = ["uid"]
+        production_keys = ["uid", "sent_on"]
         for plan in PipelineConfiguration.RQA_CODING_PLANS:
             if plan.raw_field not in production_keys:
                 production_keys.append(plan.raw_field)


### PR DESCRIPTION
These will enable future analysis of when messages are coming, and make monitoring via a production file easier.