### PR TITLE
Estimate Engagement Types

### DIFF
--- a/code_schemes/engagement_type.json
+++ b/code_schemes/engagement_type.json
@@ -1,0 +1,72 @@
+{
+  "SchemeID": "Scheme-8200076f",
+  "Name": "Engagement Type",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-5db30728",
+      "CodeType": "Normal",
+      "DisplayText": "sms ad",
+      "NumericValue": 1,
+      "StringValue": "sms_ad",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "sms_ad"
+      ]
+    },
+    {
+      "CodeID": "code-2e8d96ca",
+      "CodeType": "Normal",
+      "DisplayText": "radio promo",
+      "NumericValue": 2,
+      "StringValue" : "radio_promo",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "radio_promo"
+      ]
+    },
+    {
+      "CodeID": "code-6be5ea3b",
+      "CodeType": "Normal",
+      "DisplayText": "radio show",
+      "NumericValue": 3,
+      "StringValue" : "radio_show",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "radio_show"
+      ]
+    },
+    {
+      "CodeID": "code-94be32ba",
+      "CodeType": "Normal",
+      "DisplayText": "other",
+      "NumericValue": 4,
+      "StringValue" : "other",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "other"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false,
+      "MatchValues": [
+        "NA"
+      ]
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -29,6 +29,8 @@ class CodeSchemes(object):
     LIVELIHOOD = _open_scheme("livelihood.json")
     HOUSEHOLD_LANGUAGE = _open_scheme("household_language.json")
 
+    ENGAGEMENT_TYPE = _open_scheme("engagement_type.json")
+
     WS_CORRECT_DATASET = _open_scheme("ws_correct_dataset.json")
 
     FACEBOOK_S08E01 = _open_scheme("facebook_s08e01.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -428,56 +428,59 @@ def get_follow_up_coding_plans(pipeline_name):
 
 
 def get_engagement_coding_plans(pipeline_name):
-    assert pipeline_name == "USAID-IBTCI-SMS"
-    return [
-        CodingPlan(dataset_name="rqa_s08e01",
-                   raw_field="sent_on",
-                   coding_configurations=[
-                       CodingConfiguration(
-                           coding_mode=CodingModes.SINGLE,
-                           code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
-                           cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e01"),
-                           coded_field="rqa_s08e01_engagement_type_coded",
-                           analysis_file_key="rqa_s08e01_engagement_type",
-                           fold_strategy=None,
-                           include_in_individuals_file=False,
-                           include_in_theme_distribution=False
-                       )
-                   ],
-                   raw_field_fold_strategy=FoldStrategies.concatenate),
+    if pipeline_name == "USAID-IBTCI-Facebook":
+        return []
+    else:
+        assert pipeline_name == "USAID-IBTCI-SMS"
+        return [
+            CodingPlan(dataset_name="rqa_s08e01",
+                       raw_field="sent_on",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
+                               cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e01"),
+                               coded_field="rqa_s08e01_engagement_type_coded",
+                               analysis_file_key="rqa_s08e01_engagement_type",
+                               fold_strategy=None,
+                               include_in_individuals_file=False,
+                               include_in_theme_distribution=False
+                           )
+                       ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate),
 
-        CodingPlan(dataset_name="rqa_s08e02",
-                   raw_field="sent_on",
-                   coding_configurations=[
-                       CodingConfiguration(
-                           coding_mode=CodingModes.SINGLE,
-                           code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
-                           cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e02"),
-                           coded_field="rqa_s08e02_engagement_type_coded",
-                           analysis_file_key="rqa_s08e02_engagement_type",
-                           fold_strategy=None,
-                           include_in_individuals_file=False,
-                           include_in_theme_distribution=False
-                       )
-                   ],
-                   raw_field_fold_strategy=FoldStrategies.concatenate),
+            CodingPlan(dataset_name="rqa_s08e02",
+                       raw_field="sent_on",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
+                               cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e02"),
+                               coded_field="rqa_s08e02_engagement_type_coded",
+                               analysis_file_key="rqa_s08e02_engagement_type",
+                               fold_strategy=None,
+                               include_in_individuals_file=False,
+                               include_in_theme_distribution=False
+                           )
+                       ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate),
 
-        CodingPlan(dataset_name="rqa_s08e03",
-                   raw_field="sent_on",
-                   coding_configurations=[
-                       CodingConfiguration(
-                           coding_mode=CodingModes.SINGLE,
-                           code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
-                           cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e03"),
-                           coded_field="rqa_s08e03_engagement_type_coded",
-                           analysis_file_key="rqa_s08e03_engagement_type",
-                           fold_strategy=None,
-                           include_in_individuals_file=False,
-                           include_in_theme_distribution=False
-                       )
-                   ],
-                   raw_field_fold_strategy=FoldStrategies.concatenate)
-    ]
+            CodingPlan(dataset_name="rqa_s08e03",
+                       raw_field="sent_on",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.ENGAGEMENT_TYPE,
+                               cleaner=lambda sent_on: clean_engagement_type(isoparse(sent_on), "rqa_s08e03"),
+                               coded_field="rqa_s08e03_engagement_type_coded",
+                               analysis_file_key="rqa_s08e03_engagement_type",
+                               fold_strategy=None,
+                               include_in_individuals_file=False,
+                               include_in_theme_distribution=False
+                           )
+                       ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate)
+        ]
 
 
 def get_ws_correct_dataset_scheme(pipeline_name):

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -19,6 +19,13 @@ INDIVIDUALS_FILE = "individuals_file"
 class AnalysisFile(object):
     @staticmethod
     def export_to_csv(analysis_file_type, data, csv_path, export_keys, consent_withdrawn_key):
+        # De-duplicate export keys
+        _export_keys = export_keys
+        export_keys = []
+        for key in _export_keys:
+            if key not in export_keys:
+                export_keys.append(key)
+
         with open(csv_path, "w") as f:
             writer = csv.DictWriter(f, fieldnames=export_keys, lineterminator="\n")
             writer.writeheader()

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -26,12 +26,16 @@ class CodingConfiguration(object):
 
 # TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
-    def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
-                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
-                 message_id_fn=None):
+    def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, dataset_name=None, coda_filename=None,
+                 ws_code=None, time_field=None, run_id_field=None, icr_filename=None, id_field=None,
+                 code_imputation_function=None, message_id_fn=None):
         if message_id_fn is None:
             message_id_fn = lambda td: SHAUtils.sha_string(td[self.raw_field])
 
+        if dataset_name is None:
+            dataset_name = raw_field
+
+        self.dataset_name = dataset_name
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -41,7 +45,6 @@ class CodingPlan(object):
         self.code_imputation_function = code_imputation_function
         self.ws_code = ws_code
         self.raw_field_fold_strategy = raw_field_fold_strategy
-        self.dataset_name = raw_field
         self.message_id_fn = message_id_fn
 
         if id_field is None:

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -15,6 +15,7 @@ class PipelineConfiguration(object):
     DEMOG_CODING_PLANS = []
     FOLLOW_UP_CODING_PLANS = []
     SURVEY_CODING_PLANS = []
+    ENGAGEMENT_CODING_PLANS = []
     WS_CORRECT_DATASET_SCHEME = None
 
     def __init__(self, pipeline_name, raw_data_sources, uuid_table, timestamp_remappings,
@@ -73,8 +74,10 @@ class PipelineConfiguration(object):
         PipelineConfiguration.RQA_CODING_PLANS = coding_plans.get_rqa_coding_plans(self.pipeline_name)
         PipelineConfiguration.DEMOG_CODING_PLANS = coding_plans.get_demog_coding_plans(self.pipeline_name)
         PipelineConfiguration.FOLLOW_UP_CODING_PLANS = coding_plans.get_follow_up_coding_plans(self.pipeline_name)
+        PipelineConfiguration.ENGAGEMENT_CODING_PLANS = coding_plans.get_engagement_coding_plans(self.pipeline_name)
         PipelineConfiguration.SURVEY_CODING_PLANS += PipelineConfiguration.DEMOG_CODING_PLANS
         PipelineConfiguration.SURVEY_CODING_PLANS += PipelineConfiguration.FOLLOW_UP_CODING_PLANS
+        PipelineConfiguration.SURVEY_CODING_PLANS += PipelineConfiguration.ENGAGEMENT_CODING_PLANS
         PipelineConfiguration.WS_CORRECT_DATASET_SCHEME = coding_plans.get_ws_correct_dataset_scheme(self.pipeline_name)
 
         self.validate()


### PR DESCRIPTION
Estimates engagement types by categorising into "sms ad", "radio promo", "radio show", or "other" based on timestamps.

This is a highly tactical implementation to meet IBTCI's deadlines. I had to go to some lengths to force the existing infrastructure to handle this new categorisation. When things calm down, which should discuss how to simplify and standardise automated analyse so that this kind of update becomes easier in future, both to make to pipelines in the first place and then to copy to other pipelines too.