### PR TITLE
Add Facebook configuration for the break

### DIFF
--- a/code_schemes/facebook_s08e03_break_w01.json
+++ b/code_schemes/facebook_s08e03_break_w01.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-586a92bd",
+  "Name": "Facebook S08E03 Break W01",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/facebook_s08e03_break_w02.json
+++ b/code_schemes/facebook_s08e03_break_w02.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-8da48c34",
+  "Name": "Facebook S08E03 Break W02",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/facebook_s08e03_break_w03.json
+++ b/code_schemes/facebook_s08e03_break_w03.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-a37023e4",
+  "Name": "Facebook S08E03 Break W03",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/facebook_s08e03_break_w04.json
+++ b/code_schemes/facebook_s08e03_break_w04.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-43b6fdb6",
+  "Name": "Facebook S08E03 Break W04",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/facebook_s08e03_break_w05.json
+++ b/code_schemes/facebook_s08e03_break_w05.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-54278eca",
+  "Name": "Facebook S08E03 Break W05",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/facebook_s08e03_break_w06.json
+++ b/code_schemes/facebook_s08e03_break_w06.json
@@ -1,0 +1,116 @@
+{
+  "SchemeID": "Scheme-f2250f9e",
+  "Name": "Facebook S08E03 Break W06",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -39,5 +39,9 @@ class CodeSchemes(object):
     FACEBOOK_S08E03_BREAK_W01 = _open_scheme("facebook_s08e03_break_w01.json")
     FACEBOOK_S08E03_BREAK_W02 = _open_scheme("facebook_s08e03_break_w02.json")
     FACEBOOK_S08E03_BREAK_W03 = _open_scheme("facebook_s08e03_break_w03.json")
+    FACEBOOK_S08E03_BREAK_W04 = _open_scheme("facebook_s08e03_break_w04.json")
+    FACEBOOK_S08E03_BREAK_W05 = _open_scheme("facebook_s08e03_break_w05.json")
+    FACEBOOK_S08E03_BREAK_W06 = _open_scheme("facebook_s08e03_break_w06.json")
+
     FACEBOOK_COMMENT_REPLY_TO = _open_scheme("facebook_comment_reply_to.json")
     FACEBOOK_POST_TYPE = _open_scheme("facebook_post_type.json")

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -36,5 +36,8 @@ class CodeSchemes(object):
     FACEBOOK_S08E01 = _open_scheme("facebook_s08e01.json")
     FACEBOOK_S08E02 = _open_scheme("facebook_s08e02.json")
     FACEBOOK_S08E03 = _open_scheme("facebook_s08e03.json")
+    FACEBOOK_S08E03_BREAK_W01 = _open_scheme("facebook_s08e03_break_w01.json")
+    FACEBOOK_S08E03_BREAK_W02 = _open_scheme("facebook_s08e03_break_w02.json")
+    FACEBOOK_S08E03_BREAK_W03 = _open_scheme("facebook_s08e03_break_w03.json")
     FACEBOOK_COMMENT_REPLY_TO = _open_scheme("facebook_comment_reply_to.json")
     FACEBOOK_POST_TYPE = _open_scheme("facebook_post_type.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -126,7 +126,10 @@ def get_rqa_coding_plans(pipeline_name):
 
             _make_facebook_coding_plan("facebook_s08e03_break_w01", CodeSchemes.FACEBOOK_S08E03_BREAK_W01),
             _make_facebook_coding_plan("facebook_s08e03_break_w02", CodeSchemes.FACEBOOK_S08E03_BREAK_W02),
-            _make_facebook_coding_plan("facebook_s08e03_break_w03", CodeSchemes.FACEBOOK_S08E03_BREAK_W03)
+            _make_facebook_coding_plan("facebook_s08e03_break_w03", CodeSchemes.FACEBOOK_S08E03_BREAK_W03),
+            _make_facebook_coding_plan("facebook_s08e03_break_w04", CodeSchemes.FACEBOOK_S08E03_BREAK_W04),
+            _make_facebook_coding_plan("facebook_s08e03_break_w05", CodeSchemes.FACEBOOK_S08E03_BREAK_W05),
+            _make_facebook_coding_plan("facebook_s08e03_break_w06", CodeSchemes.FACEBOOK_S08E03_BREAK_W06)
         ]
     else:
         assert pipeline_name == "USAID-IBTCI-SMS"

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -74,128 +74,59 @@ def clean_engagement_type(sent_on, episode):
     return Codes.TRUE_MISSING
 
 
+def _make_facebook_coding_plan(name, code_scheme):
+    return \
+        CodingPlan(dataset_name=name,
+                   raw_field=f"{name}_raw",
+                   time_field="sent_on",
+                   run_id_field=f"{name}_run_id",
+                   coda_filename=f"USAID_IBTCI_{name}.json",
+                   message_id_fn=lambda td: SHAUtils.sha_string(td[f"{name}_comment_id"]),
+                   icr_filename=f"{name}.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=code_scheme,
+                           coded_field=f"{name}_coded",
+                           analysis_file_key=name,
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(code_scheme, x, y)
+                       ),
+                       CodingConfiguration(
+                           raw_field=f"{name}_comment_reply_to_raw",
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
+                           cleaner=lambda parent: "post" if parent == {} else "comment",
+                           coded_field=f"{name}_comment_reply_to_coded",
+                           requires_manual_verification=False,
+                           analysis_file_key=f"{name}_comment_reply_to",
+                           fold_strategy=None,
+                           include_in_individuals_file=False
+                       ),
+                       CodingConfiguration(
+                           raw_field=f"{name}_post_raw",
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
+                           cleaner=clean_facebook_post_type,
+                           coded_field=f"{name}_post_type_coded",
+                           requires_manual_verification=False,
+                           analysis_file_key=f"{name}_post_type",
+                           fold_strategy=None,
+                           include_in_individuals_file=False
+                       )
+                   ],
+                   raw_field_fold_strategy=FoldStrategies.concatenate)
+
+
 def get_rqa_coding_plans(pipeline_name):
     if pipeline_name == "USAID-IBTCI-Facebook":
         return [
-            CodingPlan(dataset_name="facebook_s08e01",
-                       raw_field="facebook_s08e01_raw",
-                       time_field="sent_on",
-                       run_id_field="facebook_s08e01_run_id",
-                       coda_filename="USAID_IBTCI_facebook_s08e01.json",
-                       message_id_fn=lambda td: SHAUtils.sha_string(td["facebook_s08e01_comment_id"]),
-                       icr_filename="facebook_s08e01.csv",
-                       coding_configurations=[
-                           CodingConfiguration(
-                               coding_mode=CodingModes.MULTIPLE,
-                               code_scheme=CodeSchemes.FACEBOOK_S08E01,
-                               coded_field="facebook_s08e01_coded",
-                               analysis_file_key="facebook_s08e01",
-                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S08E01, x, y)
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e01_comment_reply_to_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
-                               cleaner=lambda parent: "post" if parent == {} else "comment",
-                               coded_field="facebook_s08e01_comment_reply_to_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e01_comment_reply_to",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e01_post_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
-                               cleaner=clean_facebook_post_type,
-                               coded_field="facebook_s08e01_post_type_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e01_post_type",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           )
-                       ],
-                       raw_field_fold_strategy=FoldStrategies.concatenate),
+            _make_facebook_coding_plan("facebook_s08e01", CodeSchemes.FACEBOOK_S08E01),
+            _make_facebook_coding_plan("facebook_s08e02", CodeSchemes.FACEBOOK_S08E02),
+            _make_facebook_coding_plan("facebook_s08e03", CodeSchemes.FACEBOOK_S08E03),
 
-            CodingPlan(raw_field="facebook_s08e02_raw",
-                       time_field="sent_on",
-                       run_id_field="facebook_s08e02_run_id",
-                       coda_filename="USAID_IBTCI_facebook_s08e02.json",
-                       message_id_fn=lambda td: SHAUtils.sha_string(td["facebook_s08e02_comment_id"]),
-                       icr_filename="facebook_s08e02.csv",
-                       coding_configurations=[
-                           CodingConfiguration(
-                               coding_mode=CodingModes.MULTIPLE,
-                               code_scheme=CodeSchemes.FACEBOOK_S08E02,
-                               coded_field="facebook_s08e02_coded",
-                               analysis_file_key="facebook_s08e02",
-                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S08E02, x,
-                                                                                        y)
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e02_comment_reply_to_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
-                               cleaner=lambda parent: "post" if parent == {} else "comment",
-                               coded_field="facebook_s08e02_comment_reply_to_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e02_comment_reply_to",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e02_post_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
-                               cleaner=clean_facebook_post_type,
-                               coded_field="facebook_s08e02_post_type_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e02_post_type",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           )
-                       ],
-                       raw_field_fold_strategy=FoldStrategies.concatenate),
-
-            CodingPlan(raw_field="facebook_s08e03_raw",
-                       time_field="sent_on",
-                       run_id_field="facebook_s08e03_run_id",
-                       coda_filename="USAID_IBTCI_facebook_s08e03.json",
-                       message_id_fn=lambda td: SHAUtils.sha_string(td["facebook_s08e03_comment_id"]),
-                       icr_filename="facebook_s08e03.csv",
-                       coding_configurations=[
-                           CodingConfiguration(
-                               coding_mode=CodingModes.MULTIPLE,
-                               code_scheme=CodeSchemes.FACEBOOK_S08E03,
-                               coded_field="facebook_s08e03_coded",
-                               analysis_file_key="facebook_s08e03",
-                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S08E03, x,
-                                                                                        y)
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e03_comment_reply_to_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
-                               cleaner=lambda parent: "post" if parent == {} else "comment",
-                               coded_field="facebook_s08e03_comment_reply_to_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e03_comment_reply_to",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           ),
-                           CodingConfiguration(
-                               raw_field="facebook_s08e03_post_raw",
-                               coding_mode=CodingModes.SINGLE,
-                               code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
-                               cleaner=clean_facebook_post_type,
-                               coded_field="facebook_s08e03_post_type_coded",
-                               requires_manual_verification=False,
-                               analysis_file_key="facebook_s08e03_post_type",
-                               fold_strategy=None,
-                               include_in_individuals_file=False
-                           )
-                       ],
-                       raw_field_fold_strategy=FoldStrategies.concatenate)
+            _make_facebook_coding_plan("facebook_s08e03_break_w01", CodeSchemes.FACEBOOK_S08E03_BREAK_W01),
+            _make_facebook_coding_plan("facebook_s08e03_break_w02", CodeSchemes.FACEBOOK_S08E03_BREAK_W02),
+            _make_facebook_coding_plan("facebook_s08e03_break_w03", CodeSchemes.FACEBOOK_S08E03_BREAK_W03)
         ]
     else:
         assert pipeline_name == "USAID-IBTCI-SMS"

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -5,6 +5,7 @@ from dateutil.parser import isoparse
 
 from configuration import code_imputation_functions
 from configuration.code_schemes import CodeSchemes
+from src.facebook_utils import FacebookUtils
 from src.lib.configuration_objects import CodingConfiguration, CodingModes, CodingPlan
 
 
@@ -27,24 +28,6 @@ def clean_district_if_no_mogadishu_sub_district(text):
         return somali.DemographicCleaner.clean_somalia_district(text)
     else:
         return Codes.NOT_CODED
-
-
-def clean_facebook_post_type(post):
-    post_type = None
-    # Assume that there is only one attachment type, which is either a photo or inline_video, as this is the plan for
-    # this project. If that assumption doesn't hold, this will fail and we can adapt to what the data actually looks
-    # in that case when we see it.
-    for attachment in post["attachments"]["data"]:
-        assert attachment["type"] in {"video_inline", "photo"}, post
-
-        if attachment["type"] == "video_inline":
-            assert post_type in {"video", None}, post
-            post_type = "video"
-        elif attachment["type"] == "photo":
-            assert post_type in {"photo", None}, post
-            post_type = "photo"
-
-    return post_type
 
 
 def clean_engagement_type(sent_on, episode):
@@ -106,7 +89,7 @@ def _make_facebook_coding_plan(name, code_scheme):
                            raw_field=f"{name}_post_raw",
                            coding_mode=CodingModes.SINGLE,
                            code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
-                           cleaner=clean_facebook_post_type,
+                           cleaner=FacebookUtils.clean_post_type,
                            coded_field=f"{name}_post_type_coded",
                            requires_manual_verification=False,
                            analysis_file_key=f"{name}_post_type",

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -29,6 +29,15 @@
         }},
         {"Name": "facebook_s08e03_break_w03", "Search": {
           "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w04", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-04T00:00+03:00", "EndDate": "2021-01-10T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w05", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-11T00:00+03:00", "EndDate": "2021-01-17T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w06", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-18T00:00+03:00", "EndDate": "2021-01-24T24:00+03:00"
         }}
       ]
     },
@@ -62,6 +71,15 @@
         }},
         {"Name": "facebook_s08e03_break_w03", "Search": {
           "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w04", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-04T00:00+03:00", "EndDate": "2021-01-10T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w05", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-11T00:00+03:00", "EndDate": "2021-01-17T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w06", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-18T00:00+03:00", "EndDate": "2021-01-24T24:00+03:00"
         }}
       ]
     },
@@ -96,6 +114,15 @@
         }},
         {"Name": "facebook_s08e03_break_w03", "Search": {
           "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w04", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-04T00:00+03:00", "EndDate": "2021-01-10T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w05", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-11T00:00+03:00", "EndDate": "2021-01-17T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w06", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-18T00:00+03:00", "EndDate": "2021-01-24T24:00+03:00"
         }}
       ]
     },
@@ -129,6 +156,15 @@
         }},
         {"Name": "facebook_s08e03_break_w03", "Search": {
           "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w04", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-04T00:00+03:00", "EndDate": "2021-01-10T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w05", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-11T00:00+03:00", "EndDate": "2021-01-17T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w06", "Search": {
+          "Match": "#Hage", "StartDate": "2021-01-18T00:00+03:00", "EndDate": "2021-01-24T24:00+03:00"
         }}
       ]
     }
@@ -164,18 +200,36 @@
     {"SourceKey": "facebook_s08e03_break_w01.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s08e03_break_w01.parent", "PipelineKey": "facebook_s08e03_break_w01_comment_reply_to_raw"},
     {"SourceKey": "facebook_s08e03_break_w01.post", "PipelineKey": "facebook_s08e03_break_w01_post_raw"},
-    
+
     {"SourceKey": "facebook_s08e03_break_w02.message", "PipelineKey": "facebook_s08e03_break_w02_raw"},
     {"SourceKey": "facebook_s08e03_break_w02.id", "PipelineKey": "facebook_s08e03_break_w02_comment_id"},
     {"SourceKey": "facebook_s08e03_break_w02.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s08e03_break_w02.parent", "PipelineKey": "facebook_s08e03_break_w02_comment_reply_to_raw"},
     {"SourceKey": "facebook_s08e03_break_w02.post", "PipelineKey": "facebook_s08e03_break_w02_post_raw"},
-    
+
     {"SourceKey": "facebook_s08e03_break_w03.message", "PipelineKey": "facebook_s08e03_break_w03_raw"},
     {"SourceKey": "facebook_s08e03_break_w03.id", "PipelineKey": "facebook_s08e03_break_w03_comment_id"},
     {"SourceKey": "facebook_s08e03_break_w03.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s08e03_break_w03.parent", "PipelineKey": "facebook_s08e03_break_w03_comment_reply_to_raw"},
-    {"SourceKey": "facebook_s08e03_break_w03.post", "PipelineKey": "facebook_s08e03_break_w03_post_raw"}
+    {"SourceKey": "facebook_s08e03_break_w03.post", "PipelineKey": "facebook_s08e03_break_w03_post_raw"},
+    
+    {"SourceKey": "facebook_s08e03_break_w04.message", "PipelineKey": "facebook_s08e03_break_w04_raw"},
+    {"SourceKey": "facebook_s08e03_break_w04.id", "PipelineKey": "facebook_s08e03_break_w04_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w04.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w04.parent", "PipelineKey": "facebook_s08e03_break_w04_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w04.post", "PipelineKey": "facebook_s08e03_break_w04_post_raw"},
+    
+    {"SourceKey": "facebook_s08e03_break_w05.message", "PipelineKey": "facebook_s08e03_break_w05_raw"},
+    {"SourceKey": "facebook_s08e03_break_w05.id", "PipelineKey": "facebook_s08e03_break_w05_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w05.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w05.parent", "PipelineKey": "facebook_s08e03_break_w05_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w05.post", "PipelineKey": "facebook_s08e03_break_w05_post_raw"},
+    
+    {"SourceKey": "facebook_s08e03_break_w06.message", "PipelineKey": "facebook_s08e03_break_w06_raw"},
+    {"SourceKey": "facebook_s08e03_break_w06.id", "PipelineKey": "facebook_s08e03_break_w06_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w06.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w06.parent", "PipelineKey": "facebook_s08e03_break_w06_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w06.post", "PipelineKey": "facebook_s08e03_break_w06_post_raw"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -17,8 +17,18 @@
           "342722832782775_1506611219727258",
           "342722832782775_1508439062877807"
         ]},
-         {"Name": "facebook_s08e03", "Search": {
+        {"Name": "facebook_s08e03", "Search": {
           "Match": "#BarnaamijkaHage", "StartDate": "2020-11-16T00:00+03:00", "EndDate": "2020-11-22T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w01", "PostIDs": [
+          "342722832782775_1536801340041579",
+          "342722832782775_1534482843606762"
+        ]},
+        {"Name": "facebook_s08e03_break_w02", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-21T00:00+03:00", "EndDate": "2020-12-27T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w03", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
         }}
       ]
     },
@@ -42,7 +52,17 @@
           "1584334095169246_2809122856023691",
           "1584334095169246_2811698025766174",
           "1584334095169246_2813726475563329"
-        ]}
+        ]},
+        {"Name": "facebook_s08e03_break_w01", "PostIDs": [
+          "1584334095169246_2837055806563729",
+          "1584334095169246_2834635423472434"
+        ]},
+        {"Name": "facebook_s08e03_break_w02", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-21T00:00+03:00", "EndDate": "2020-12-27T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w03", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }}
       ]
     },
     {
@@ -66,7 +86,17 @@
           "325301151525528_708474849874821",
           "325301151525528_710463649675941",
           "325301151525528_711934782862161"
-        ]}
+        ]},
+        {"Name": "facebook_s08e03_break_w01", "PostIDs": [
+          "325301151525528_728662131189426",
+          "325301151525528_726958141359825"
+        ]},
+        {"Name": "facebook_s08e03_break_w02", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-21T00:00+03:00", "EndDate": "2020-12-27T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w03", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }}
       ]
     },
     {
@@ -89,7 +119,17 @@
           "548414038603623_3228851770559823",
           "548414038603623_3236211706490496",
           "548414038603623_3242196812558652"
-        ]}
+        ]},
+        {"Name": "facebook_s08e03_break_w01", "PostIDs":  [
+          "548414038603623_3311236498988016",
+          "548414038603623_3303736583071341"
+        ]},
+        {"Name": "facebook_s08e03_break_w02", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-21T00:00+03:00", "EndDate": "2020-12-27T24:00+03:00"
+        }},
+        {"Name": "facebook_s08e03_break_w03", "Search": {
+          "Match": "#Hage", "StartDate": "2020-12-28T00:00+03:00", "EndDate": "2021-01-03T24:00+03:00"
+        }}
       ]
     }
   ],
@@ -117,7 +157,25 @@
     {"SourceKey": "facebook_s08e03.id", "PipelineKey": "facebook_s08e03_comment_id"},
     {"SourceKey": "facebook_s08e03.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s08e03.parent", "PipelineKey": "facebook_s08e03_comment_reply_to_raw"},
-    {"SourceKey": "facebook_s08e03.post", "PipelineKey": "facebook_s08e03_post_raw"}
+    {"SourceKey": "facebook_s08e03.post", "PipelineKey": "facebook_s08e03_post_raw"},
+
+    {"SourceKey": "facebook_s08e03_break_w01.message", "PipelineKey": "facebook_s08e03_break_w01_raw"},
+    {"SourceKey": "facebook_s08e03_break_w01.id", "PipelineKey": "facebook_s08e03_break_w01_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w01.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w01.parent", "PipelineKey": "facebook_s08e03_break_w01_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w01.post", "PipelineKey": "facebook_s08e03_break_w01_post_raw"},
+    
+    {"SourceKey": "facebook_s08e03_break_w02.message", "PipelineKey": "facebook_s08e03_break_w02_raw"},
+    {"SourceKey": "facebook_s08e03_break_w02.id", "PipelineKey": "facebook_s08e03_break_w02_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w02.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w02.parent", "PipelineKey": "facebook_s08e03_break_w02_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w02.post", "PipelineKey": "facebook_s08e03_break_w02_post_raw"},
+    
+    {"SourceKey": "facebook_s08e03_break_w03.message", "PipelineKey": "facebook_s08e03_break_w03_raw"},
+    {"SourceKey": "facebook_s08e03_break_w03.id", "PipelineKey": "facebook_s08e03_break_w03_comment_id"},
+    {"SourceKey": "facebook_s08e03_break_w03.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s08e03_break_w03.parent", "PipelineKey": "facebook_s08e03_break_w03_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s08e03_break_w03.post", "PipelineKey": "facebook_s08e03_break_w03_post_raw"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -23,6 +23,9 @@ DATASETS=(
     "USAID_IBTCI_facebook_s08e01"
     "USAID_IBTCI_facebook_s08e02"
     "USAID_IBTCI_facebook_s08e03"
+    "USAID_IBTCI_facebook_s08e03_break_w01"
+    "USAID_IBTCI_facebook_s08e03_break_w02"
+    "USAID_IBTCI_facebook_s08e03_break_w03"
 
     "CSAP_age"
     "CSAP_gender"

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -26,6 +26,9 @@ DATASETS=(
     "USAID_IBTCI_facebook_s08e03_break_w01"
     "USAID_IBTCI_facebook_s08e03_break_w02"
     "USAID_IBTCI_facebook_s08e03_break_w03"
+    "USAID_IBTCI_facebook_s08e03_break_w04"
+    "USAID_IBTCI_facebook_s08e03_break_w05"
+    "USAID_IBTCI_facebook_s08e03_break_w06"
 
     "CSAP_age"
     "CSAP_gender"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -23,6 +23,9 @@ DATASETS=(
     "USAID_IBTCI_facebook_s08e01"
     "USAID_IBTCI_facebook_s08e02"
     "USAID_IBTCI_facebook_s08e03"
+    "USAID_IBTCI_facebook_s08e03_break_w01"
+    "USAID_IBTCI_facebook_s08e03_break_w02"
+    "USAID_IBTCI_facebook_s08e03_break_w03"
 
     "CSAP_age"
     "CSAP_gender"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -26,6 +26,9 @@ DATASETS=(
     "USAID_IBTCI_facebook_s08e03_break_w01"
     "USAID_IBTCI_facebook_s08e03_break_w02"
     "USAID_IBTCI_facebook_s08e03_break_w03"
+    "USAID_IBTCI_facebook_s08e03_break_w04"
+    "USAID_IBTCI_facebook_s08e03_break_w05"
+    "USAID_IBTCI_facebook_s08e03_break_w06"
 
     "CSAP_age"
     "CSAP_gender"

--- a/src/facebook_utils.py
+++ b/src/facebook_utils.py
@@ -13,9 +13,9 @@ class FacebookUtils(object):
         """
         post_type = None
         for attachment in post["attachments"]["data"]:
-            assert attachment["type"] in {"video_inline", "photo"}, post
+            assert attachment["type"] in {"video_inline", "video_direct_response", "photo"}, post
 
-            if attachment["type"] == "video_inline":
+            if attachment["type"] in {"video_inline", "video_direct_response"}:
                 assert post_type in {"video", None}, post
                 post_type = "video"
             elif attachment["type"] == "photo":


### PR DESCRIPTION
We're asking one question each week for 6 weeks while the radio shows are on pause (which are most likely to be used to guide question design rather than need full analysis). The questions on Facebook will then sync with the remaining radio shows after the mid-season break (hence the slightly unusual terminology here: facebook_s08e03_break_w*).