### PR TITLE
Use workspace name as contacts file name

### DIFF
--- a/configuration/sms_pipeline_config.json
+++ b/configuration/sms_pipeline_config.json
@@ -5,7 +5,6 @@
       "SourceType": "RapidPro",
       "Domain": "textit.in",
       "TokenFileURL": "gs://avf-credentials/csap-text-it-token.txt",
-      "ContactsFileName": "csap_contacts",
       "ActivationFlowNames": [
 
       ],
@@ -26,7 +25,6 @@
       "SourceType": "RapidPro",
       "Domain": "textit.in",
       "TokenFileURL": "gs://avf-credentials/csap-2-textit-token.txt",
-      "ContactsFileName": "csap_2_contacts",
       "ActivationFlowNames": [
         "csap_s08e01_activation",
         "csap_s08e02_activation",

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -63,10 +63,11 @@ def fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir,
         google_cloud_credentials_file_path, rapid_pro_source.token_file_url).strip()
 
     rapid_pro = RapidProClient(rapid_pro_source.domain, rapid_pro_token)
+    workspace_name = rapid_pro.get_workspace_name()
 
     # Load the previous export of contacts if it exists, otherwise fetch all contacts from Rapid Pro.
-    raw_contacts_path = f"{raw_data_dir}/{rapid_pro_source.contacts_file_name}_raw.json"
-    contacts_log_path = f"{raw_data_dir}/{rapid_pro_source.contacts_file_name}_log.jsonl"
+    raw_contacts_path = f"{raw_data_dir}/{workspace_name}_contacts_raw.json"
+    contacts_log_path = f"{raw_data_dir}/{workspace_name}_contacts_log.jsonl"
     try:
         log.info(f"Loading raw contacts from file '{raw_contacts_path}'...")
         with open(raw_contacts_path) as raw_contacts_file:

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -184,15 +184,12 @@ class RawDataSource(ABC):
 
 
 class RapidProSource(RawDataSource):
-    def __init__(self, domain, token_file_url, contacts_file_name, activation_flow_names, survey_flow_names,
-                 test_contact_uuids):
+    def __init__(self, domain, token_file_url, activation_flow_names, survey_flow_names, test_contact_uuids):
         """
         :param domain: URL of the Rapid Pro server to download data from.
         :type domain: str
         :param token_file_url: GS URL of a text file containing the authorisation token for the Rapid Pro server.
         :type token_file_url: str
-        :param contacts_file_name:
-        :type contacts_file_name: str
         :param activation_flow_names: The names of the RapidPro flows that contain the radio show responses.
         :type: activation_flow_names: list of str
         :param survey_flow_names: The names of the RapidPro flows that contain the survey responses.
@@ -204,7 +201,6 @@ class RapidProSource(RawDataSource):
         """
         self.domain = domain
         self.token_file_url = token_file_url
-        self.contacts_file_name = contacts_file_name
         self.activation_flow_names = activation_flow_names
         self.survey_flow_names = survey_flow_names
         self.test_contact_uuids = test_contact_uuids
@@ -221,18 +217,15 @@ class RapidProSource(RawDataSource):
     def from_configuration_dict(cls, configuration_dict):
         domain = configuration_dict["Domain"]
         token_file_url = configuration_dict["TokenFileURL"]
-        contacts_file_name = configuration_dict["ContactsFileName"]
         activation_flow_names = configuration_dict.get("ActivationFlowNames", [])
         survey_flow_names = configuration_dict.get("SurveyFlowNames", [])
         test_contact_uuids = configuration_dict.get("TestContactUUIDs", [])
 
-        return cls(domain, token_file_url, contacts_file_name, activation_flow_names,
-                   survey_flow_names, test_contact_uuids)
+        return cls(domain, token_file_url, activation_flow_names, survey_flow_names, test_contact_uuids)
 
     def validate(self):
         validators.validate_string(self.domain, "domain")
         validators.validate_string(self.token_file_url, "token_file_url")
-        validators.validate_string(self.contacts_file_name, "contacts_file_name")
 
         validators.validate_list(self.activation_flow_names, "activation_flow_names")
         for i, activation_flow_name in enumerate(self.activation_flow_names):


### PR DESCRIPTION
Now that get_workspace_name() exists in RapidProTools we can use that to distinguish the contacts files for each workspace, allowing us to remove a slightly confusing and now unnecessary piece of configuration.